### PR TITLE
Add Transfer-Encoding to list of header to not send

### DIFF
--- a/redfishMockupServer.py
+++ b/redfishMockupServer.py
@@ -116,7 +116,8 @@ class RfMockupServer(BaseHTTPRequestHandler):
             # there is no request data, so no need to dump that
             print("   GET: Headers: {}".format(self.headers))
             sys.stdout.flush()
-            dont_send = ["Connection", "Keep-Alive", "Content-Length"]
+            # specify headers to not send (use lowercase)
+            dont_send = ["connection", "keep-alive", "content-length", "transfer-encoding"]
             rfile = "index.json"
             rfileXml = "index.xml"
             rhfile = "headers.json"
@@ -178,7 +179,7 @@ class RfMockupServer(BaseHTTPRequestHandler):
                         d = json.load(headers_data)
                     if isinstance(d["GET"], dict):
                         for k, v in d["GET"].items():
-                            if k not in dont_send:
+                            if k.lower() not in dont_send:
                                 self.send_header(str(k), str(v))
                 elif (os.path.isfile(fhpath) is False):
                     self.send_header("Content-Type", "application/json")


### PR DESCRIPTION
During Plugfest, a mockup was created from a service that returned responses using chunking (header `"Transfer-Encoding": "chunked"`). When that mockup was served up by the mockup server, it included the Transfer-Encoding header that specified "chunked," but of course was not using chunked transfer encoding. This resulted in clients failing to be able to read responses from the mockup server.

Added Transfer-Encoding to list of response headers to not send. Also updated the "don't send" logic to do case-insensitive matching on the headers.

Fixes #38 