### PR TITLE
Fix errors in command-line arg processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ pip3 install -r requirements.txt
 * Copy the ***redfishMockupServer.py*** file to the the folder you want to execute it from.
 * Use the `-D <mockupDir>` option to specify an absolute or relative path to the mockup dir from CWD.
 * Use the `-T` option to tell mockup server to include response delay from the mockup time.json file.
-* Use the `-t <responseTime>` option to change default delay in seconds to each response. Default is 0 sec. Must be float or int.
-* Use the `-X` or `--headers` option to tell mockup server to send headers. Loads from headers.json. If not, defaults are sent.
+* Use the `-t <responseTime>` option to change default delay in seconds to each response. Default is 0 seconds. Must be float or int.
+* Use the `-X` or `--headers` option to tell mockup server to send headers. Loads from headers.json. If not, standard headers are sent.
 * Use the `-s` option to specify SSL (HTTPS) protocol.
  * In order for the server to function, you must also specify `--cert` and `--key` files.
 * Note that the mockup directory will normally start with `/redfish`:
@@ -47,25 +47,37 @@ pip3 install -r requirements.txt
 * Usage:
 
 ```
-Usage: redfishMockupServer.py <options>
-  options:
-    -h, --help                               # Display usage syntax
-    -H <host>, --host <host>, --Host <host>  # Hostname or IP addr, default: 127.0.0.1
-    -p <port>, --port <port>, --Port <port>  # Host port, default: 8000
-    -D <dir>, --dir <dir>, --Dir <dir>       # Path to the mockup directory; may be relative to CWD
-    -X, --headers                            # Load headers from headers.json files
-    -t <delay>, --time <delay>               # Delay time in seconds added to request; must be float or int
-    -E, --test-etag, --TestEtag              # (unimplemented) etag testing
-    -T                                       # Delay response based on times in time.json files
-    -s, --ssl                                # Place server in SSL (HTTPS) mode; requires a certificate and key
-    --cert <cert>                            # Specify a certificate for SSL
-    --key <key>                              # Specify a key for SSL
-    -S, --short-form, --shortForm            # Apply short form to mockup (omit filepath /redfish/v1)
-    -P, --ssdp                               # Make mockup SSDP discoverable
+usage: redfishMockupServer.py [-h] [-H HOST] [-p PORT] [-D DIR] [-E] [-X]
+                              [-t TIME] [-T] [-s] [--cert CERT] [--key KEY]
+                              [-S] [-P]
+
+Serve a static Redfish mockup.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -H HOST, --host HOST, --Host HOST
+                        hostname or IP address (default 127.0.0.1)
+  -p PORT, --port PORT, --Port PORT
+                        host port (default 8000)
+  -D DIR, --dir DIR, --Dir DIR
+                        path to mockup dir (may be relative to CWD)
+  -E, --test-etag, --TestEtag
+                        (unimplemented) etag testing
+  -X, --headers         load headers from headers.json files in mockup
+  -t TIME, --time TIME  delay in seconds added to responses (float or int)
+  -T                    delay response based on times in time.json files in
+                        mockup
+  -s, --ssl             place server in SSL (HTTPS) mode; requires a cert and
+                        key
+  --cert CERT           the certificate for SSL
+  --key KEY             the key for SSL
+  -S, --short-form, --shortForm
+                        apply short form to mockup (omit filepath /redfish/v1)
+  -P, --ssdp            make mockup SSDP discoverable
 ```
 
 * Example:    
- * Start another service on port 8001 from folder `./MyServerMockup9`:
+ * Start another service on port 8001 from folder _./MyServerMockup9_:
 `python redfishMockupServer.py -p 8001 -D ./MyServerMockup9`
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -21,36 +21,52 @@ pip3 install -r requirements.txt
 
 ### To start the server:
 
-* copy the ***redfishMockupServer.py*** file to the the folder you want to execute it from
-* use the `-D <mockupDir>` option to specify an absolute or relative path to the mockup dir from CWD
-* use the `-T` option to tell mockup server to include response delay in time.
-* use the `-t <responseTime>` option to change default delay in seconds to each response. Default is 0 sec. Must be float or int.
-* use the `-X` or `--headers` option to tell mockup server, to send headers. Loads from headers.json. If not, defaults are sent.
-* use the `-s` option to specify https protocol
- * In order for the server to function, you must also include `--cert` and `--key` files for the server to function
-* Note that the mockup directory must start with /redfish:  
- * "redfish" should be a sub-directory.   
- * This is a "Tall Mockup" which includes /redfish/v1 in the mockup directory structure in case some of the URIs in the mockup do not start with /redfish/v1.
- * If you wish to use a "Short" Mockup, use the `-S` modifier
-* make sure python34 is in your path
-* run redfishMockupServer from your windows command shell eg: `.\redfishMockupServer [-D <mockupDir>]`
-* Default hostname/IP is localhost:  127.0.0.1
-* Default port is:  8000
-* You can create multiple mockup servers running on multiple ports:
+* Copy the ***redfishMockupServer.py*** file to the the folder you want to execute it from.
+* Use the `-D <mockupDir>` option to specify an absolute or relative path to the mockup dir from CWD.
+* Use the `-T` option to tell mockup server to include response delay from the mockup time.json file.
+* Use the `-t <responseTime>` option to change default delay in seconds to each response. Default is 0 sec. Must be float or int.
+* Use the `-X` or `--headers` option to tell mockup server to send headers. Loads from headers.json. If not, defaults are sent.
+* Use the `-s` option to specify SSL (HTTPS) protocol.
+ * In order for the server to function, you must also specify `--cert` and `--key` files.
+* Note that the mockup directory will normally start with `/redfish`:
+ * `redfish` should be a sub-directory.
+ * This is a "Tall Mockup" which includes `/redfish/v1` at the top of the mockup directory structure.
+ * A "Short Mockup" does not include `/redfish/v1` at the top of the mockup tree.
+ * If you wish to use a "Short Mockup", use the `-S` option.
+* Make sure python version 3.4+ is in your path
+* Run redfishMockupServer from your command shell, e.g.: `python redfishMockupServer.py [-D <mockupDir>]`
+* Default hostname/IP is localhost: 127.0.0.1
+* Default port is: 8000
+* You can create multiple mockup servers running on different ports using the `-p` option.
+* See **Options** section below for additional options.
 
 ### Options:
 
-* `redfishMockupServer -h`     -- gives help usage and exits
+* `python redfishMockupServer.py -h` -- gives help usage and exits
 
-* `redfishMockupServer [-H *HostIpAddress* ] [-P *port*] [-D <mockupDir>] [-H <host>] [-P <port>] [-T] [-t <responseTime>] [-X] [-E]`
-  * default *HostIpAddress* is 127.0.0.1
-  * default *port*         is 8000
-  * *mockupDir* is absolute or relative to CWD if starting with . or ..
-  * -T option causes mockup server to include delay in reponse. Loads from time.json . If not, looks up the default delay time.
-  * `-t <responseTime>` tells the mockup server to add `<responseTime>` default delay to each response.  Default is 0 sec. Must be float or int
-  * `-X` or `--headers` tells the mockup server to send headers from headers.json file
+* Usage:
+
+```
+Usage: redfishMockupServer.py <options>
+  options:
+    -h, --help                               # Display usage syntax
+    -H <host>, --host <host>, --Host <host>  # Hostname or IP addr, default: 127.0.0.1
+    -p <port>, --port <port>, --Port <port>  # Host port, default: 8000
+    -D <dir>, --dir <dir>, --Dir <dir>       # Path to the mockup directory; may be relative to CWD
+    -X, --headers                            # Load headers from headers.json files
+    -t <delay>, --time <delay>               # Delay time in seconds added to request; must be float or int
+    -E, --test-etag, --TestEtag              # (unimplemented) etag testing
+    -T                                       # Delay response based on times in time.json files
+    -s, --ssl                                # Place server in SSL (HTTPS) mode; requires a certificate and key
+    --cert <cert>                            # Specify a certificate for SSL
+    --key <key>                              # Specify a key for SSL
+    -S, --short-form, --shortForm            # Apply short form to mockup (omit filepath /redfish/v1)
+    -P, --ssdp                               # Make mockup SSDP discoverable
+```
+
 * Example:    
-`.\redfishMockupServer -P 8001 -D ./MyServerMockup9 -X `   # to start another service on port 8001 from folder *./MyServerMockup9*
+ * Start another service on port 8001 from folder `./MyServerMockup9`:
+`python redfishMockupServer.py -p 8001 -D ./MyServerMockup9`
 
 ## Release Process
 

--- a/redfishMockupServer.py
+++ b/redfishMockupServer.py
@@ -604,16 +604,16 @@ class RfMockupServer(BaseHTTPRequestHandler):
 
 
 def usage(program):
-        logger.info("usage: {} <options>".format(program))
+        logger.info("Usage: {} <options>".format(program))
         logger.info("  options:")
         logger.info("    -h, --help                               # Display usage syntax")
         logger.info("    -H <host>, --host <host>, --Host <host>  # Hostname or IP addr, default: 127.0.0.1")
         logger.info("    -p <port>, --port <port>, --Port <port>  # Host port, default: 8000")
         logger.info("    -D <dir>, --dir <dir>, --Dir <dir>       # Path to the mockup directory; may be relative to CWD")
-        logger.info("    -X, --headers                            # Load headers from json files")
+        logger.info("    -X, --headers                            # Load headers from headers.json files")
         logger.info("    -t <delay>, --time <delay>               # Delay time in seconds added to request; must be float or int")
         logger.info("    -E, --test-etag, --TestEtag              # (unimplemented) etag testing")
-        logger.info("    -T                                       # Delay response based on times in time.json")
+        logger.info("    -T                                       # Delay response based on times in time.json files")
         logger.info("    -s, --ssl                                # Place server in SSL (HTTPS) mode; requires a certificate and key")
         logger.info("    --cert <cert>                            # Specify a certificate for SSL")
         logger.info("    --key <key>                              # Specify a key for SSL")

--- a/redfishMockupServer.py
+++ b/redfishMockupServer.py
@@ -604,20 +604,21 @@ class RfMockupServer(BaseHTTPRequestHandler):
 
 
 def usage(program):
-        logger.info("usage: {}   [-h][-P][-H <hostIpAddr>:<port>]".format(program))
-        logger.info("      -h --help      # logger.infos usage ")
-        logger.info("      -H <IpAddr>   --Host=<IpAddr>    # hostIP, default: 127.0.0.1")
-        logger.info("      -p <port>     --port=<port>      # port:  default is 8000")
-        logger.info("      -D <dir>,     --Dir=<dir>        # Path to the mockup directory. It may be relative to CWD")
-        logger.info("      -X,           --headers          # Option to load headers or not from json files")
-        logger.info("      -t <delay>    --time=<delayTime> # Delay Time in seconds added to any request. Must be float or int.")
-        logger.info("      -E            --TestEtag         # (unimplemented) etag testing--enable returning etag for certain APIs for testing.  See Readme")
-        logger.info("      -T                               # Option to delay response or not.")
-        logger.info("      -s            --ssl              # Places server in https, requires a certificate and key")
-        logger.info("      --cert <cert>                    # Specify a certificate for ssl server function")
-        logger.info("      --key <key>                      # Specify a key for ssl")
-        logger.info("      -S            --shortForm        # Apply shortform to mockup (allowing to omit filepath /redfish/v1)")
-        logger.info("      -P            --ssdp             # Make mockup ssdp discoverable (by redfish specification)")
+        logger.info("usage: {} <options>".format(program))
+        logger.info("  options:")
+        logger.info("    -h, --help                               # Display usage syntax")
+        logger.info("    -H <host>, --host <host>, --Host <host>  # Hostname or IP addr, default: 127.0.0.1")
+        logger.info("    -p <port>, --port <port>, --Port <port>  # Host port, default: 8000")
+        logger.info("    -D <dir>, --dir <dir>, --Dir <dir>       # Path to the mockup directory; may be relative to CWD")
+        logger.info("    -X, --headers                            # Load headers from json files")
+        logger.info("    -t <delay>, --time <delay>               # Delay time in seconds added to request; must be float or int")
+        logger.info("    -E, --test-etag, --TestEtag              # (unimplemented) etag testing")
+        logger.info("    -T                                       # Delay response based on times in time.json")
+        logger.info("    -s, --ssl                                # Place server in SSL (HTTPS) mode; requires a certificate and key")
+        logger.info("    --cert <cert>                            # Specify a certificate for SSL")
+        logger.info("    --key <key>                              # Specify a key for SSL")
+        logger.info("    -S, --short-form, --shortForm            # Apply short form to mockup (omit filepath /redfish/v1)")
+        logger.info("    -P, --ssdp                               # Make mockup SSDP discoverable")
 
 
 def main(argv):
@@ -638,11 +639,15 @@ def main(argv):
         ssdpStart = False
         logger.info("Redfish Mockup Server, version {}".format(tool_version))
         try:
-            opts, args = getopt.getopt(argv[1:], "hTSPsEH:p:D:t:X", ["help", "shortForm", "ssdp", "ssl", "TestEtag", "headers", "Host=", "Port=", "Dir=",
-                                                                    "time=", "cert=", "key="])
-        except getopt.GetoptError:
+            opts, args = getopt.getopt(argv[1:], "hTSPsEH:p:D:t:X",
+                                       ["help", "shortForm", "short-form",
+                                        "ssdp", "ssl", "TestEtag", "test-etag",
+                                        "headers", "Host=", "host=", "Port=",
+                                        "port=", "Dir=", "dir=", "time=",
+                                        "cert=", "key="])
+        except getopt.GetoptError as e:
             # usage()
-            logger.info("Error parsing options")
+            logger.info("Error parsing options: {}".format(e))
             sys.stderr.flush()
             usage(program)
             sys.exit(2)
@@ -651,15 +656,15 @@ def main(argv):
             if opt in ("-h", "--help"):
                 usage(program)
                 sys.exit(0)
-            elif opt in ("-H", "--Host"):
+            elif opt in ("-H", "--host", "--Host"):
                 hostname = arg
             elif opt in ("-X", "--headers"):
                 headers = True
-            elif opt in ("-p", "--port"):
+            elif opt in ("-p", "--port", "--Port"):
                 port = int(arg)
-            elif opt in ("-D", "--Dir"):
+            elif opt in ("-D", "--dir", "--Dir"):
                 mockDirPath = arg
-            elif opt in ("-E", "--TestEtag"):
+            elif opt in ("-E", "--test-etag", "--TestEtag"):
                 testEtagFlag = True
             elif opt in ("-t", "--time"):
                 responseTime = arg
@@ -671,12 +676,12 @@ def main(argv):
                 sslCert = arg
             elif opt in ("--key",):
                 sslKey = arg
-            elif opt in ("-S", "--shortForm"):
+            elif opt in ("-S", "--short-form", "--shortForm"):
                 shortForm = True
             elif opt in ("-P", "--ssdp"):
                 ssdpStart = True
             else:
-                logger.info('unhandled option')
+                logger.info('unhandled option: {}'.format(opt))
                 sys.exit(2)
 
         logger.info('program: {}'.format(program))

--- a/redfishMockupServer.py
+++ b/redfishMockupServer.py
@@ -6,7 +6,7 @@
 # tested and developed Python 3.4
 
 import sys
-import getopt
+import argparse
 import time
 import collections
 import json
@@ -603,92 +603,53 @@ class RfMockupServer(BaseHTTPRequestHandler):
                     return (self.server.responseTime)
 
 
-def usage(program):
-        logger.info("Usage: {} <options>".format(program))
-        logger.info("  options:")
-        logger.info("    -h, --help                               # Display usage syntax")
-        logger.info("    -H <host>, --host <host>, --Host <host>  # Hostname or IP addr, default: 127.0.0.1")
-        logger.info("    -p <port>, --port <port>, --Port <port>  # Host port, default: 8000")
-        logger.info("    -D <dir>, --dir <dir>, --Dir <dir>       # Path to the mockup directory; may be relative to CWD")
-        logger.info("    -X, --headers                            # Load headers from headers.json files")
-        logger.info("    -t <delay>, --time <delay>               # Delay time in seconds added to request; must be float or int")
-        logger.info("    -E, --test-etag, --TestEtag              # (unimplemented) etag testing")
-        logger.info("    -T                                       # Delay response based on times in time.json files")
-        logger.info("    -s, --ssl                                # Place server in SSL (HTTPS) mode; requires a certificate and key")
-        logger.info("    --cert <cert>                            # Specify a certificate for SSL")
-        logger.info("    --key <key>                              # Specify a key for SSL")
-        logger.info("    -S, --short-form, --shortForm            # Apply short form to mockup (omit filepath /redfish/v1)")
-        logger.info("    -P, --ssdp                               # Make mockup SSDP discoverable")
+def main():
 
-
-def main(argv):
-        hostname = "127.0.0.1"
-        port = 8000
-        program = argv[0]
-        logger.info(program)
-        mockDirPath = None
-        sslMode = False
-        sslCert = None
-        sslKey = None
-        mockDir = None
-        testEtagFlag = False
-        responseTime = 0
-        timefromJson = False
-        headers = False
-        shortForm = False
-        ssdpStart = False
         logger.info("Redfish Mockup Server, version {}".format(tool_version))
-        try:
-            opts, args = getopt.getopt(argv[1:], "hTSPsEH:p:D:t:X",
-                                       ["help", "shortForm", "short-form",
-                                        "ssdp", "ssl", "TestEtag", "test-etag",
-                                        "headers", "Host=", "host=", "Port=",
-                                        "port=", "Dir=", "dir=", "time=",
-                                        "cert=", "key="])
-        except getopt.GetoptError as e:
-            # usage()
-            logger.info("Error parsing options: {}".format(e))
-            sys.stderr.flush()
-            usage(program)
-            sys.exit(2)
 
-        for opt, arg in opts:
-            if opt in ("-h", "--help"):
-                usage(program)
-                sys.exit(0)
-            elif opt in ("-H", "--host", "--Host"):
-                hostname = arg
-            elif opt in ("-X", "--headers"):
-                headers = True
-            elif opt in ("-p", "--port", "--Port"):
-                port = int(arg)
-            elif opt in ("-D", "--dir", "--Dir"):
-                mockDirPath = arg
-            elif opt in ("-E", "--test-etag", "--TestEtag"):
-                testEtagFlag = True
-            elif opt in ("-t", "--time"):
-                responseTime = arg
-            elif opt in ("-T"):
-                timefromJson = True
-            elif opt in ("-s", "--ssl"):
-                sslMode = True
-            elif opt in ("--cert",):
-                sslCert = arg
-            elif opt in ("--key",):
-                sslKey = arg
-            elif opt in ("-S", "--short-form", "--shortForm"):
-                shortForm = True
-            elif opt in ("-P", "--ssdp"):
-                ssdpStart = True
-            else:
-                logger.info('unhandled option: {}'.format(opt))
-                sys.exit(2)
+        parser = argparse.ArgumentParser(description='Serve a static Redfish mockup.')
+        parser.add_argument('-H', '--host', '--Host', default='127.0.0.1',
+                            help='hostname or IP address (default 127.0.0.1)')
+        parser.add_argument('-p', '--port', '--Port', default=8000, type=int,
+                            help='host port (default 8000)')
+        parser.add_argument('-D', '--dir', '--Dir',
+                            help='path to mockup dir (may be relative to CWD)')
+        parser.add_argument('-E', '--test-etag', '--TestEtag',
+                            action='store_true',
+                            help='(unimplemented) etag testing')
+        parser.add_argument('-X', '--headers', action='store_true',
+                            help='load headers from headers.json files in mockup')
+        parser.add_argument('-t', '--time', default=0,
+                            help='delay in seconds added to responses (float or int)')
+        parser.add_argument('-T', action='store_true',
+                            help='delay response based on times in time.json files in mockup')
+        parser.add_argument('-s', '--ssl', action='store_true',
+                            help='place server in SSL (HTTPS) mode; requires a cert and key')
+        parser.add_argument('--cert', help='the certificate for SSL')
+        parser.add_argument('--key', help='the key for SSL')
+        parser.add_argument('-S', '--short-form', '--shortForm', action='store_true',
+                            help='apply short form to mockup (omit filepath /redfish/v1)')
+        parser.add_argument('-P', '--ssdp', action='store_true',
+                            help='make mockup SSDP discoverable')
 
-        logger.info('program: {}'.format(program))
+        args = parser.parse_args()
+        hostname = args.host
+        port = args.port
+        mockDirPath = args.dir
+        testEtagFlag = args.test_etag
+        headers = args.headers
+        responseTime = args.time
+        timefromJson = args.T
+        sslMode = args.ssl
+        sslCert = args.cert
+        sslKey = args.key
+        shortForm = args.short_form
+        ssdpStart = args.ssdp
+
         logger.info('Hostname: {}'.format(hostname))
         logger.info('Port: {}'.format(port))
-        logger.info("dir path specified by user:{}".format(mockDirPath))
-        logger.info("response time: {} seconds".format(responseTime))
+        logger.info("Mockup directory path specified: {}".format(mockDirPath))
+        logger.info("Response time: {} seconds".format(responseTime))
 
         # check if mockup path was specified.  If not, use current working directory
         if mockDirPath is None:
@@ -696,7 +657,7 @@ def main(argv):
 
         # create the full path to the top directory holding the Mockup
         mockDir = os.path.realpath(mockDirPath)  # creates real full path including path for CWD to the -D<mockDir> dir path
-        logger.info("Serving Mockup in abs real directory path:{}".format(mockDir))
+        logger.info("Serving Mockup in absolute path: {}".format(mockDir))
 
         # check that we have a valid tall mockup--with /redfish in mockDir before proceeding
         if not shortForm:
@@ -727,7 +688,7 @@ def main(argv):
         try:
             myServer.responseTime = float(responseTime)
         except ValueError as e:
-            logger.info("Enter a integer or float value")
+            logger.info("Enter an integer or float value")
             sys.exit(2)
         # myServer.me="HELLO"
 
@@ -757,7 +718,7 @@ def main(argv):
 
 # the below is only executed if the program is run as a script
 if __name__ == "__main__":
-        main(sys.argv)
+        main()
 
 '''
 TODO:


### PR DESCRIPTION
The were some errors in the command-line argument processing, like a longopt of `--Port` being declared, but the option processing code looking for `--port`.

Make the following updates:

- Cleaned up the inconsistent longopt declarations and processing
- For longopts that were capitalized, I added lowercase versions as well since capitalized logopts are not standard practice (e.g. it now support both `--Port` and `--port`)
- Cleaned up the README.md to be accurate in showing the options and examples

Fixes #51 
