### PR TITLE
Adds a docker-compose setup to ease launch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Invoke with docker run -p 8000:80 <dockerimageid>
+# Then use by browsing http://localhost:8000
+FROM debian:9
+MAINTAINER bruno.cornec@hpe.com
+ENV DEBIAN_FRONTEND noninterative
+# Install deps for Redfish mockup
+RUN apt-get update
+RUN apt-get -y install apache2 unzip sed patch vim wget iproute2 python3 python3-requests
+ENV MODELPORT=$MODELPORT
+EXPOSE $MODELPORT
+RUN mkdir -p /mockup
+COPY redfishMockupServer.py /mockup
+COPY rfSsdpServer.py /mockup
+COPY run-mockup.sh /mockup
+CMD /mockup/run-mockup.sh

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ optional arguments:
   -P, --ssdp            make mockup SSDP discoverable
 ```
 
+* `redfishMockupServer [-H *HostIpAddress* ] [-D <mockupDir>] [-H <host>] [-p <port>] [-T] [-t <responseTime>] [-X] [-E]`
+  * default *HostIpAddress* is 127.0.0.1
+  * default *port*         is 8000
+  * *mockupDir* is absolute or relative to CWD if starting with . or ..
+  * -T option causes mockup server to include delay in reponse. Loads from time.json . If not, looks up the default delay time.
+  * `-t <responseTime>` tells the mockup server to add `<responseTime>` default delay to each response.  Default is 0 sec. Must be float or int
+  * `-X` or `--headers` tells the mockup server to send headers from headers.json file
 * Example:    
  * Start another service on port 8001 from folder _./MyServerMockup9_:
 `python redfishMockupServer.py -p 8001 -D ./MyServerMockup9`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.2"
+services:
+
+  redfish-mockup-server:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    image: redfish-mockup-server:latest
+    ports:
+      - "8111:8111"
+    container_name: redfish-mockup-server
+    environment:
+      - MODELPORT=8111
+    volumes:
+      - /tmp/mockup/model:/mockup/model

--- a/redfishMockupServer.py
+++ b/redfishMockupServer.py
@@ -13,7 +13,7 @@ import json
 import threading
 import datetime
 
-import grequests
+import requests
 
 import os
 import ssl
@@ -698,15 +698,14 @@ def main():
             monkey.patch_all()
             # construct path "mockdir/path/to/resource/<filename>"
             path, filename, jsonData = '/redfish/v1', 'index.json', None
-            apath = myServer.mockDir
             rpath = clean_path(path, myServer.shortForm)
-            fpath = os.path.join(apath, rpath, filename) if filename not in ['', None] else os.path.join(apath, rpath)
-            if os.path.isfile(fpath):
-                with open(fpath) as f:
-                    jsonData = json.load(f)
-                    f.close()
-            else:
-                jsonData = None
+            # this is the real absolute path to the mockup directory
+            apath = myServer.mockDir
+            # form the path in the mockup of the file
+            #      old only support mockup in CWD:  apath=os.path.abspath(rpath)
+            #fpath = os.path.join(apath, rpath, filename) if filename not in ['', None] else os.path.join(apath, rpath)
+            fpath = myServer.construct_path(path, filename)
+            success, item = myServer.get_cached_link(fpath)
             protocol = '{}://'.format('https' if sslMode else 'http')
             mySDDP = RfSDDPServer(jsonData, '{}{}:{}{}'.format(protocol, hostname, port, '/redfish/v1'), hostname)
 

--- a/run-mockup.sh
+++ b/run-mockup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# 
+# Launch the mockup
+cd /mockup
+MODELIP="redfish-mockup-server"
+cmd="./redfishMockupServer.py -H $MODELIP -p $MODELPORT -D /mockup/model"
+echo "Launching $cmd"
+python3 $cmd


### PR DESCRIPTION
This allows to run the code generated with DMTF/Redfish-Mockup-Creator in a Docker container. 
This has been successfully tested with the HPE simulator at https://ilorestfulapiexplorer.ext.hpe.com/

In link with https://github.com/DMTF/Redfish-Mockup-Creator/pull/41

Another approach could be to have an upper project seeing both Creator and Server and a single docker-compose file managing both.
