### PR TITLE
Support binary files in a mockup

### DIFF
--- a/redfishMockupServer.py
+++ b/redfishMockupServer.py
@@ -515,20 +515,41 @@ class RfMockupServer(BaseHTTPRequestHandler):
                 self.wfile.write(encoded_data)
 
             # if XML...
-            elif(os.path.isfile(fpath_xml) or os.path.isfile(fpath_direct)):
-                if os.path.isfile(fpath_xml):
-                    file_extension = 'xml'
-                    f = open(fpath_xml, "r")
-                elif os.path.isfile(fpath_direct):
-                    filename, file_extension = os.path.splitext(fpath_direct)
-                    file_extension = file_extension.strip('.')
-                    f = open(fpath_direct, "r")
+            elif os.path.isfile(fpath_xml):
+                f = open(fpath_xml, "r")
                 self.send_response(200)
-                self.send_header("Content-Type", "application/" + file_extension + ";odata.metadata=minimal;charset=utf-8")
+                self.send_header("Content-Type", "application/xml;odata.metadata=minimal;charset=utf-8")
                 self.send_header("OData-Version", "4.0")
                 self.end_headers()
                 self.wfile.write(f.read().encode())
                 f.close()
+
+            elif os.path.isfile(fpath_direct):
+                self.send_response(200)
+                with open(fpath_direct, 'rb') as f:
+                    content = f.read()
+
+                try:
+                    decoded_content = content.decode()
+                except ValueError:
+                    # If the file is binary, send it as octet-stream.
+                    self.send_header("Content-Type", "application/octet-stream;"
+                                     "odata.metadata=minimal")
+                    self.send_header("OData-Version", "4.0")
+                    self.end_headers()
+                    self.wfile.write(content)
+                else:
+                    # The file is text.
+                    file_extension = os.path.splitext(fpath_direct)[1]
+                    if file_extension == "":
+                        mime_type = "text/plain"
+                    else:
+                        mime_type = "application/" + file_extension[1:]
+                    self.send_header("Content-Type", mime_type + ";odata.metadata=minimal;charset=utf-8")
+                    self.send_header("OData-Version", "4.0")
+                    self.end_headers()
+                    self.wfile.write(decoded_content.encode("utf-8"))
+
             else:
                 self.send_response(404)
                 self.end_headers()

--- a/redfishMockupServer.py
+++ b/redfishMockupServer.py
@@ -406,7 +406,7 @@ class RfMockupServer(BaseHTTPRequestHandler):
                         filename, file_extension = os.path.splitext(fpath_direct)
                         file_extension = file_extension.strip('.')
                     self.send_response(200)
-                    self.send_header("Content-Type", "application/" + file_extension + ";odata.metadata=minimal;charset=utf-8")
+                    self.send_header("Content-Type", "application/" + file_extension + ";charset=utf-8")
                     self.send_header("OData-Version", "4.0")
                 else:
                     self.send_response(404)
@@ -474,7 +474,7 @@ class RfMockupServer(BaseHTTPRequestHandler):
                 # Query Subscriptions should not return HttpHeaders.
                 if 'EventService/Subscriptions' in self.path:
                    if output_data.get('HttpHeaders') is not None:
-                      # This array is null or an empty array in responses. 
+                      # This array is null or an empty array in responses.
                       # An empty array is the preferred return value on read operations.
                       output_data['HttpHeaders'] = []
 
@@ -511,14 +511,14 @@ class RfMockupServer(BaseHTTPRequestHandler):
                 if not (self.server.headers and (os.path.isfile(fpath_headers))):
                     self.send_header("Content-Length", len(encoded_data))
                 self.end_headers()
-                
+
                 self.wfile.write(encoded_data)
 
             # if XML...
             elif os.path.isfile(fpath_xml):
                 f = open(fpath_xml, "r")
                 self.send_response(200)
-                self.send_header("Content-Type", "application/xml;odata.metadata=minimal;charset=utf-8")
+                self.send_header("Content-Type", "application/xml;charset=utf-8")
                 self.send_header("OData-Version", "4.0")
                 self.end_headers()
                 self.wfile.write(f.read().encode())
@@ -533,8 +533,7 @@ class RfMockupServer(BaseHTTPRequestHandler):
                     decoded_content = content.decode()
                 except ValueError:
                     # If the file is binary, send it as octet-stream.
-                    self.send_header("Content-Type", "application/octet-stream;"
-                                     "odata.metadata=minimal")
+                    self.send_header("Content-Type", "application/octet-stream")
                     self.send_header("OData-Version", "4.0")
                     self.end_headers()
                     self.wfile.write(content)
@@ -545,7 +544,7 @@ class RfMockupServer(BaseHTTPRequestHandler):
                         mime_type = "text/plain"
                     else:
                         mime_type = "application/" + file_extension[1:]
-                    self.send_header("Content-Type", mime_type + ";odata.metadata=minimal;charset=utf-8")
+                    self.send_header("Content-Type", mime_type + ";charset=utf-8")
                     self.send_header("OData-Version", "4.0")
                     self.end_headers()
                     self.wfile.write(decoded_content.encode("utf-8"))


### PR DESCRIPTION
This commit adds support for binary files in a mockup. This is useful if a mockup contains things like a sysdump.