### PR TITLE
Import Mapping from collections.abc

### DIFF
--- a/redfishMockupServer.py
+++ b/redfishMockupServer.py
@@ -9,7 +9,7 @@ import re
 import sys
 import argparse
 import time
-import collections
+import collections.abc
 import json
 import threading
 import datetime
@@ -47,7 +47,7 @@ def dict_merge(dct, merge_dct):
         :return: None
         """
         for k in merge_dct:
-            if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], collections.Mapping)):
+            if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], collections.abc.Mapping)):
                 dict_merge(dct[k], merge_dct[k])
             else:
                 dct[k] = merge_dct[k]


### PR DESCRIPTION
'Mapping' is an abstract class and therefore should be imported from 'collections.abc'.  

Importing 'Mapping' from 'collections' is deprecated since Python 3.3 and has been removed in 3.10.