### PR TITLE
Fixed bug where server would get stuck in infinite loop when adding a member.

### DIFF
--- a/redfishMockupServer.py
+++ b/redfishMockupServer.py
@@ -682,6 +682,8 @@ class RfMockupServer(BaseHTTPRequestHandler):
                             self.send_response(204)
                             self.send_header("Location", newpath)
                             self.send_header("Content-Length", "0")
+                            if 'SessionService/Sessions' in self.path:
+                                self.send_header("X-Auth-Token", "1234567890ABCDEF")
                             self.end_headers()
 
                     # Actions framework


### PR DESCRIPTION
Fix for #98. This should prevent an infinite loop in the event of adding a member when:

- No ID is present but an existing member exists with no number in the end (occurs when requesting a session using the `publicrackmount1` schema example)
- An ID specified in the body is added that already exists in members. If so it defaults to the pattern made by the first member (less likely to happen as you usually wouldn’t POST with an ID).

I encountered this immediately upon spinning up the mockup server to use a redfish query tool which naturally requested a session. I understand that Redfish-Mockup-Server is meant to be a demo limited in functionality and scope, however I’m hoping these fixes just add a bit more reliability for those that don’t want to spend time debugging or changing their mockup server schema.