### PR TITLE
Added linux/arm64 image support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,20 +75,21 @@ jobs:
       run: |
         gh release create ${{github.event.inputs.version}} -t ${{github.event.inputs.version}} -n "Changes since last release:"$'\n\n'"$CHANGES"
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
     - name: Login to Docker Hub
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v3
       with:
         username: ${{secrets.DOCKER_USERNAME}}
         password: ${{secrets.DOCKER_PASSWORD}}
     - name: Build Docker image and push
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         context: .
         push: true
         tags: dmtf/redfish-mockup-server:${{github.event.inputs.version}}
+        platforms: linux/arm64,linux/amd64
     - name: Image digest
       run: echo ${{steps.docker_build.outputs.digest}}


### PR DESCRIPTION
Issue: Using the Docker image under macOS with an arm64 chip causes deadlocks when calling mock files. Seems like there is an issue with the Rosetta 2 emulation for x86. Running the application without Docker on macOS works fine. Tested a local arm64 build with docker and it seems to fixed.

Solution: Added arm64 architecture to the Docker image build process which also allows macOS users to run that image. Also updated the GitHub pipeline actions.